### PR TITLE
Add .gitattributes for the language display

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+assembler/* linguist-vendored
+


### PR DESCRIPTION
Currently the project is classified as a c project because of the assembler source code.
This gives contributors the wrong idea as there is no c in the CodeGuru engine. 

Adding the .gitattributes helps the GitHub linguist put the right language labels for the GitHub project.