### PR TITLE
Fix bug with immediate in instruction format S

### DIFF
--- a/src/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_formats/InstructionFormatS.java
+++ b/src/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_formats/InstructionFormatS.java
@@ -22,8 +22,9 @@ public class InstructionFormatS extends InstructionFormatBase
                         ((funct3 & mask(3)) << 12) |
                         ((rs1 & mask(5)) << 15) |
                         ((rs2 & mask(5)) << 20) |
-                        (((imm >> 5) & mask(7) << 25))
+                        ((((imm >> 5) & mask(7)) << 25))
         );
+
     }
 
     @Override
@@ -47,9 +48,11 @@ public class InstructionFormatS extends InstructionFormatBase
         return (byte)((this.raw >> 20) & mask(5));
     }
 
-    public byte getImm() {
+    public short getImm() {
         int first_part = (byte)((this.raw >> 7) & mask(5));
-        int second_part = (byte)(this.raw >> 25);
-        return (byte)(first_part | (second_part << 5));
+        int second_part = (byte)((this.raw >> 25) & mask(7));
+        // Sign-extend the result
+        int shift = 32 - 12;
+        return (short)((first_part | (second_part << 5)) << shift >> shift);
     }
 }

--- a/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionDecoderRv32c.java
+++ b/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionDecoderRv32c.java
@@ -312,10 +312,8 @@ public class InstructionDecoderRv32c {
                          * It expands to "sw rs2, offset[7:2](x2)".
                          */
                         CInstructionFormatCSS css = new CInstructionFormatCSS(i);
-                        int cssbit76 = css.getImmediate() & 3;
-                        int cssbit52 = (css.getImmediate() >> 2) & 15;
-                        int cssuimm = (cssbit52 | (cssbit76 << 4)) << 2;
-                        return new Instruction(RV32C.Opcodes.CSWSP, RV32I.instructionS(RV32I.Opcodes.Sw, 2, css.getRs2(), cssuimm),
+
+                        return new Instruction(RV32C.Opcodes.CSWSP, RV32I.instructionS(RV32I.Opcodes.Sw, 2, css.getRs2(), css.getWord()),
                                 (InstructionFormatBase format, InstructionRunner runner) -> runner.sw(new InstructionFormatS(format)));
                 }
         }

--- a/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/RV32C.java
+++ b/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/RV32C.java
@@ -20,6 +20,10 @@ public final class RV32C {
         return new CInstructionFormatCSS((byte)info.getOpcode(), (byte)info.getFunct3(), (byte)rs2, (byte) imm);
     }
 
+    public static CInstructionFormatCSS cInstructionFormatCSSwithWord(Instruction.InstructionInfo info, int rs2, int imm) {
+        return CInstructionFormatCSS.createWithWord((byte)info.getOpcode(), (byte)info.getFunct3(), (byte)rs2, (byte) imm);
+    }
+
     public static CInstructionFormatCIW cInstructionFormatCIW(Instruction.InstructionInfo info, int rd, int imm) {
         assert rd >= 8 && rd < 16;
         return new CInstructionFormatCIW((byte)info.getOpcode(), (byte)info.getFunct3(), (byte)(rd-8), (byte)imm);

--- a/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/instruction_formats/CInstructionFormatCSS.java
+++ b/src/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/instruction_formats/CInstructionFormatCSS.java
@@ -17,11 +17,26 @@ public class CInstructionFormatCSS extends CInstructionFormatBase {
                 ((funct3 & mask(3)) << 13)));
     }
 
+    public static CInstructionFormatCSS createWithWord(byte opcode, byte funct3, byte rs2, byte imm)
+    {
+        int bit76 = (imm >> 6) & mask(2);
+        int bit52 = (imm >> 2) & mask(4);
+        byte word = (byte)(bit76 | (bit52 << 2));
+        return new CInstructionFormatCSS(opcode, funct3, rs2, word);
+    }
+
     public byte getRs2() {
         return (byte) ((raw >> 2) & mask(5));
     }
 
     public byte getImmediate() {
         return (byte) ((raw >> 7) & mask(6));
+    }
+
+    public short getWord()
+    {
+        int bit76 = this.getImmediate() & mask(2);
+        int bit52 = (this.getImmediate() >> 2) & mask(4);
+        return (short)(((bit52 | (bit76 << 4)) << 2) & mask(8));
     }
 }

--- a/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/StoreTest.java
+++ b/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/StoreTest.java
@@ -65,7 +65,7 @@ public class StoreTest {
         state.setReg(RS2_INDEX, VAL);
         loadInstruction(RV32I.instructionS(RV32I.Opcodes.Sh, RS1_INDEX, RS2_INDEX, imm));
         cpu.nextOpcode();
-        assertEquals(VAL, memory.loadWord(expectedAddress));
+        assertEquals(VAL, memory.loadHalfWord(expectedAddress));
     }
 
     @Test
@@ -79,6 +79,6 @@ public class StoreTest {
         state.setReg(RS2_INDEX, VAL);
         loadInstruction(RV32I.instructionS(RV32I.Opcodes.Sb, RS1_INDEX, RS2_INDEX, imm));
         cpu.nextOpcode();
-        assertEquals(VAL, memory.loadWord(expectedAddress));
+        assertEquals(VAL, memory.loadByte(expectedAddress));
     }
 }

--- a/test/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionFormatTest.java
+++ b/test/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionFormatTest.java
@@ -85,6 +85,16 @@ public class InstructionFormatTest {
     }
 
     @Test
+    public void testCssCreateFromWord()
+    {
+        CInstructionFormatCSS css = CInstructionFormatCSS.createWithWord((byte)0,(byte)0,(byte)0,(byte)0);
+        assertEquals((short)0, css.getRaw());
+
+        css = CInstructionFormatCSS.createWithWord((byte)2, (byte)6, (byte)5, (byte)20);
+        assertEquals((short)0xCA16, css.getRaw());
+    }
+
+    @Test
     public void testCiw()
     {
         CInstructionFormatCIW ciw = new CInstructionFormatCIW((short)0);

--- a/test/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionTest.java
+++ b/test/il/co/codeguru/corewars_riscv/cpu/riscv/rv32c/InstructionTest.java
@@ -187,21 +187,22 @@ public class InstructionTest {
     public void testSwsp() throws MemoryException, CpuException {
         state.setReg(RS1, VAL);
         state.setReg(2, 15);
-        loadInstruction(RV32C.cInstructionFormatCSS(RV32C.Opcodes.CSWSP, RS1, 0));
+        loadInstruction(RV32C.cInstructionFormatCSSwithWord(RV32C.Opcodes.CSWSP, RS1, 0));
         cpu.nextOpcode();
         assertEquals(VAL, memory.loadWord(15));
 
         state.setReg(RS1, VAL);
         state.setReg(2, 15);
-        loadInstruction(RV32C.cInstructionFormatCSS(RV32C.Opcodes.CSWSP, RS1, 20));
+        loadInstruction(RV32C.cInstructionFormatCSSwithWord(RV32C.Opcodes.CSWSP, RS1, 20));
         cpu.nextOpcode();
         assertEquals(VAL, memory.loadWord(35));
 
         state.setReg(RS1, VAL);
         state.setReg(2, 0);
-        loadInstruction(RV32C.cInstructionFormatCSS(RV32C.Opcodes.CSWSP, RS1, -15));
+        // 252 is the largest offset that can be in SWSP
+        loadInstruction(RV32C.cInstructionFormatCSSwithWord(RV32C.Opcodes.CSWSP, RS1, 252));
         cpu.nextOpcode();
-        assertNotEquals(VAL, memory.loadWord((-15) & 0xFFFF));
+        assertEquals(VAL, memory.loadWord(252));
     }
 
     @Test


### PR DESCRIPTION
Fixed the bug that was in the parsing of the immediate in the S Format, and on the way took the liberty to improve the test quality.
Fixes #13.