### PR TITLE
fixed jalr when both oporands are the same register

### DIFF
--- a/src/il/co/codeguru/corewars_riscv/cpu/riscv/InstructionRunner.java
+++ b/src/il/co/codeguru/corewars_riscv/cpu/riscv/InstructionRunner.java
@@ -238,8 +238,7 @@ public class InstructionRunner {
      * JAL stores the address of the instruction following the jump (pc+4) into register rd.
      */
     public void jal(InstructionFormatUJ i) {
-        state.setReg(i.getRd(), state.getPc() + 4);
-        jump(state, i.getImmediate());
+        jal(i, 4);
     }
 
     public void jal(InstructionFormatUJ i, int instructionSize) {
@@ -258,8 +257,9 @@ public class InstructionRunner {
     }
 
     public void jalr(InstructionFormatI i, int instructionSize) {
-        state.setReg(i.getRd(), state.getPc() + instructionSize);
+        int tmpPc = state.getPc();
         state.setPc(state.getReg(i.getRs1()) + i.getImmediate() - instructionSize);
+        state.setReg(i.getRd(), tmpPc + instructionSize);
     }
 
     /**

--- a/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/JumpTest.java
+++ b/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/JumpTest.java
@@ -97,7 +97,7 @@ public class JumpTest {
             "12,32, 0,   32,16",
             "12,32,16,   48,16"
     })
-    public void testJalrSameSrcDst()(int initialPc, int reg, int imm, int expectedPc, int expectedReg) throws MemoryException, CpuException {
+    public void testJalrSameSrcDst(int initialPc, int reg, int imm, int expectedPc, int expectedReg) throws MemoryException, CpuException {
         state.setReg(RD_INDEX, reg);
         state.setPc(initialPc);
         loadInstruction(RV32I.instructionI(RV32I.Opcodes.Jalr, RD_INDEX, RD_INDEX, imm));

--- a/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/JumpTest.java
+++ b/test/il/co/codeguru/corewars_riscv/cpu/riscv/instruction_tests/JumpTest.java
@@ -85,6 +85,26 @@ public class JumpTest {
         assertEquals(expectedPc, state.getPc());
         assertEquals(expectedReg, state.getReg(RD_INDEX));
     }
+    
+    
+    /*
+     * Test for the case where jalr is called with the source register and destination register are the same
+     * such as <code>jalr x3, x3</code>
+     */
+    @Test
+    @Parameters({
+            " 0, 8, 0,    8, 4",
+            "12,32, 0,   32,16",
+            "12,32,16,   48,16"
+    })
+    public void testJalrSameSrcDst()(int initialPc, int reg, int imm, int expectedPc, int expectedReg) throws MemoryException, CpuException {
+        state.setReg(RD_INDEX, reg);
+        state.setPc(initialPc);
+        loadInstruction(RV32I.instructionI(RV32I.Opcodes.Jalr, RD_INDEX, RD_INDEX, imm));
+        cpu.nextOpcode();
+        assertEquals(expectedPc, state.getPc());
+        assertEquals(expectedReg, state.getReg(RD_INDEX));
+    }
 
     /*
      * As of RV32C, jumps no longer throw a misaligned memory load exception when reaching an address that


### PR DESCRIPTION
when you would perform an action such as `jalr x4, x4`, it would not jump because it would set the value of x4 to the current location and the set pc to x4, which is now the current pc. this code fixes that problem